### PR TITLE
TST/BUG: Test cases for feature size and eccentricity

### DIFF
--- a/mr/feature.py
+++ b/mr/feature.py
@@ -139,7 +139,7 @@ def refine(raw_image, image, radius, coord, iterations=10):
 
     # Characterize the neighborhood of our final centroid.
     mass = neighborhood.sum()
-    Rg = np.sqrt(np.sum(radius_mask(radius, ndim)*neighborhood)/mass)
+    Rg = np.sqrt(np.sum(r_squared_mask(radius, ndim)*neighborhood)/mass)
     # I only know how to measure eccentricity in 2D.
     if ndim == 2:
         ecc = np.sqrt(np.sum(neighborhood*cosmask(radius))**2 +
@@ -366,15 +366,15 @@ def binary_mask(radius, ndim, separation=None):
 
 
 @memo
-def radius_mask(radius, ndim):
+def r_squared_mask(radius, ndim):
     points = np.arange(-radius, radius + 1)
     if ndim > 1:
         coords = np.array(np.meshgrid(*([points]*ndim)))
     else:
         coords = points.reshape(1, -1)
-    r = np.sqrt(np.sum(coords**2, 0))
-    r[r > radius] = 0
-    return r
+    r2 = np.sum(coords**2, 0)
+    r2[r2 > radius**2] = 0
+    return r2
 
 
 @memo

--- a/mr/tests/test_feature.py
+++ b/mr/tests/test_feature.py
@@ -209,3 +209,45 @@ class TestFeatureIdentification(unittest.TestCase):
         actual = actual.sort(['x', 'y'])  # sort for reliable comparison
         expected = DataFrame([[7, 7]], columns=cols).sort(['x', 'y'])
         assert_allclose(actual, expected, atol=PRECISION)
+
+    def test_rg(self):
+        # For Gaussians with radii 2, 3, 5, and 7 px, with proportionately
+        # chosen feature (mask) sizes, the 'size' comes out to be within 10%
+        # of the true Gaussian width.
+
+        # The IDL code has mistake in this area, documented here:
+        # http://www.physics.emory.edu/~weeks/idl/radius.html
+
+        L = 101 
+        dims = (L, L + 2)  # avoid square images in tests
+        pos = np.array([50, 55])
+        cols = ['x', 'y']
+
+        SIZE = 2
+        image = np.ones(dims, dtype='uint8')
+        draw_gaussian_spot(image, pos[::-1], SIZE)
+        actual = mr.locate(image, 7, 1, preprocess=False)['size']
+        expected = SIZE
+        assert_allclose(actual, expected, rtol=0.1)
+
+        SIZE = 3
+        image = np.ones(dims, dtype='uint8')
+        draw_gaussian_spot(image, pos[::-1], SIZE)
+        actual = mr.locate(image, 11, 1, preprocess=False)['size']
+        expected = SIZE
+        assert_allclose(actual, expected, rtol=0.1)
+
+        SIZE = 5
+        image = np.ones(dims, dtype='uint8')
+        draw_gaussian_spot(image, pos[::-1], SIZE)
+        actual = mr.locate(image, 17, 1, preprocess=False)['size']
+        expected = SIZE
+        assert_allclose(actual, expected, rtol=0.1)
+        
+        SIZE = 7
+        image = np.ones(dims, dtype='uint8')
+        draw_gaussian_spot(image, pos[::-1], SIZE)
+        actual = mr.locate(image, 23, 1, preprocess=False)['size']
+        expected = SIZE
+        assert_allclose(actual, expected, rtol=0.1)
+        


### PR DESCRIPTION
Size is accurate within 10% as long as you choose an appropriate mask size.

Eccentricity is good within 0.02 unless the mask size is much too small.
